### PR TITLE
add missing options for some commands, and some arguments can be empty

### DIFF
--- a/cmd/node/cmd.go
+++ b/cmd/node/cmd.go
@@ -28,8 +28,14 @@ func Command() *cli.Command {
 				Action:    utils.ExitCoder(cmdNodeRemove),
 			},
 			{
-				Name:      "workloads",
-				Usage:     "list node workloads",
+				Name:  "workloads",
+				Usage: "list node workloads",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "label",
+						Usage: "labels to filter, e.g, a=1, b=2",
+					},
+				},
 				Aliases:   []string{"containers"},
 				ArgsUsage: nodeArgsUsage,
 				Action:    utils.ExitCoder(cmdNodeListWorkloads),

--- a/cmd/node/workloads.go
+++ b/cmd/node/workloads.go
@@ -13,11 +13,13 @@ import (
 type listNodeWorkloadsOptions struct {
 	client corepb.CoreRPCClient
 	name   string
+	labels map[string]string
 }
 
 func (o *listNodeWorkloadsOptions) run(ctx context.Context) error {
 	resp, err := o.client.ListNodeWorkloads(ctx, &corepb.GetNodeOptions{
 		Nodename: o.name,
+		Labels:   o.labels,
 	})
 	if err != nil {
 		return err
@@ -41,6 +43,7 @@ func cmdNodeListWorkloads(c *cli.Context) error {
 	o := &listNodeWorkloadsOptions{
 		client: client,
 		name:   name,
+		labels: utils.SplitEquality(c.StringSlice("label")),
 	}
 	return o.run(c.Context)
 }

--- a/cmd/pod/cmd.go
+++ b/cmd/pod/cmd.go
@@ -56,6 +56,10 @@ func Command() *cli.Command {
 						Usage: "list all nodes or just living nodes",
 						Value: false,
 					},
+					&cli.StringSliceFlag{
+						Name:  "label",
+						Usage: "labels to filter, e.g, a=1, b=2",
+					},
 				},
 			},
 			{

--- a/cmd/pod/nodes.go
+++ b/cmd/pod/nodes.go
@@ -3,7 +3,6 @@ package pod
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/projecteru2/cli/cmd/utils"
 	"github.com/projecteru2/cli/describe"
 	corepb "github.com/projecteru2/core/rpc/gen"
@@ -14,12 +13,14 @@ type listPodNodesOptions struct {
 	client corepb.CoreRPCClient
 	name   string
 	all    bool
+	labels map[string]string
 }
 
 func (o *listPodNodesOptions) run(ctx context.Context) error {
 	resp, err := o.client.ListPodNodes(ctx, &corepb.ListNodesOptions{
 		Podname: o.name,
 		All:     o.all,
+		Labels:  o.labels,
 	})
 	if err != nil {
 		return err
@@ -35,15 +36,11 @@ func cmdPodListNodes(c *cli.Context) error {
 		return err
 	}
 
-	name := c.Args().First()
-	if name == "" {
-		return errors.New("Pod name must be given")
-	}
-
 	o := &listPodNodesOptions{
 		client: client,
-		name:   name,
+		name:   c.Args().First(),
 		all:    c.Bool("all"),
+		labels: utils.SplitEquality(c.StringSlice("label")),
 	}
 	return o.run(c.Context)
 }

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -34,7 +34,15 @@ func Command() *cli.Command {
 					&cli.StringFlag{
 						Name:  "tail",
 						Value: "all",
-						Usage: "how many",
+						Usage: `number of lines to show from the end of the logs (default "all")`,
+					},
+					&cli.StringFlag{
+						Name:  "since",
+						Usage: "show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)",
+					},
+					&cli.StringFlag{
+						Name:  "until",
+						Usage: "show logs before a timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)",
 					},
 				},
 				Action: utils.ExitCoder(cmdWorkloadLogs),
@@ -188,7 +196,7 @@ func Command() *cli.Command {
 			},
 			{
 				Name:      "dissociate",
-				Usage:     "Dissociate workload(s) from eru, return it resource but not remove it",
+				Usage:     "dissociate workload(s) from eru, return it resource but not remove it",
 				ArgsUsage: workloadArgsUsage,
 				Action:    utils.ExitCoder(cmdWorkloadDissociate),
 			},

--- a/cmd/workload/list.go
+++ b/cmd/workload/list.go
@@ -2,7 +2,6 @@ package workload
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/projecteru2/cli/cmd/utils"
@@ -58,14 +57,9 @@ func cmdWorkloadList(c *cli.Context) error {
 		return err
 	}
 
-	appname := c.Args().First()
-	if appname == "" {
-		return fmt.Errorf("appname must be specified")
-	}
-
 	o := &listWorkloadsOptions{
 		client:     client,
-		appname:    appname,
+		appname:    c.Args().First(),
 		entrypoint: c.String("entry"),
 		nodename:   c.String("nodename"),
 		labels:     utils.SplitEquality(c.StringSlice("label")),

--- a/cmd/workload/logs.go
+++ b/cmd/workload/logs.go
@@ -16,12 +16,16 @@ type workloadLogsOptions struct {
 	client corepb.CoreRPCClient
 	id     string
 	tail   string
+	since  string
+	until  string
 }
 
 func (o *workloadLogsOptions) run(ctx context.Context) error {
 	opts := &corepb.LogStreamOptions{
-		Id:   o.id,
-		Tail: o.tail,
+		Id:    o.id,
+		Tail:  o.tail,
+		Since: o.since,
+		Until: o.until,
 	}
 	resp, err := o.client.LogStream(ctx, opts)
 	if err != nil {
@@ -62,6 +66,8 @@ func cmdWorkloadLogs(c *cli.Context) error {
 		client: client,
 		id:     id,
 		tail:   c.String("tail"),
+		since:  c.String("since"),
+		until:  c.String("until"),
 	}
 	return o.run(c.Context)
 }


### PR DESCRIPTION
* add some missing options like `--label`, `--since`, `--until` for some commands
* sometimes we can leave `appname`, `entrypoint`, `nodename` empty to retrieve all, so the checks are removed