### PR TITLE
feat: Introduce calculation of capacity for pods

### DIFF
--- a/cmd/node/get.go
+++ b/cmd/node/get.go
@@ -45,7 +45,7 @@ func (o *getNodeOptions) run(ctx context.Context) error {
 	if node.GetInitStorage() > 0 {
 		logrus.Infof("Storage Used: %d bytes", node.GetStorageUsed())
 	} else {
-		logrus.Infof("Storage Used: %d bytes (%s)", node.GetStorageUsed(), "UNLIMITED")
+		logrus.Infof("No Storage Space Available")
 	}
 	return nil
 }

--- a/cmd/pod/capacity.go
+++ b/cmd/pod/capacity.go
@@ -1,0 +1,84 @@
+package pod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/juju/errors"
+	"github.com/projecteru2/cli/cmd/utils"
+	"github.com/projecteru2/cli/describe"
+	corepb "github.com/projecteru2/core/rpc/gen"
+	"github.com/urfave/cli/v2"
+)
+
+type capacityPodOptions struct {
+	client corepb.CoreRPCClient
+	name   string
+
+	cpu     float64
+	cpuBind bool
+	memory  int64
+	storage int64
+}
+
+func (o *capacityPodOptions) run(ctx context.Context) error {
+	resp, err := o.client.CalculateCapacity(ctx, &corepb.DeployOptions{
+		// resource definitions
+		ResourceOpts: &corepb.ResourceOptions{
+			CpuQuotaLimit:   o.cpu,
+			CpuQuotaRequest: o.cpu,
+			CpuBind:         o.cpuBind,
+			MemoryLimit:     o.memory,
+			MemoryRequest:   o.memory,
+			StorageLimit:    o.storage,
+			StorageRequest:  o.storage,
+		},
+
+		// deploy options
+		Entrypoint: &corepb.EntrypointOptions{
+			Name: uuid.New().String(),
+		},
+		DeployStrategy: corepb.DeployOptions_DUMMY,
+		Podname:        o.name,
+	})
+	if err != nil {
+		return err
+	}
+
+	describe.PodCapacity(resp.Total, resp.NodeCapacities)
+	return nil
+}
+
+func cmdPodCapacity(c *cli.Context) error {
+	client, err := utils.NewCoreRPCClient(c)
+	if err != nil {
+		return err
+	}
+
+	name := c.Args().First()
+	if name == "" {
+		return errors.New("Pod name must be given")
+	}
+
+	mem, err := utils.ParseRAMInHuman(c.String("memory"))
+	if err != nil {
+		return fmt.Errorf("[cmdPodCapacity] parse memory failed %v", err)
+	}
+
+	storage, err := utils.ParseRAMInHuman(c.String("storage"))
+	if err != nil {
+		return fmt.Errorf("[cmdPodCapacity] parse storage failed %v", err)
+	}
+
+	o := &capacityPodOptions{
+		client: client,
+		name:   name,
+
+		cpu:     c.Float64("cpu-limit"),
+		cpuBind: c.Bool("cpu-bind"),
+		memory:  mem,
+		storage: storage,
+	}
+	return o.run(c.Context)
+}

--- a/cmd/pod/cmd.go
+++ b/cmd/pod/cmd.go
@@ -46,6 +46,37 @@ func Command() *cli.Command {
 				Action:    utils.ExitCoder(cmdPodResource),
 			},
 			{
+				Name:      "capacity",
+				Usage:     "pod remained capacity",
+				ArgsUsage: podArgsUsage,
+				Action:    utils.ExitCoder(cmdPodCapacity),
+				Flags: []cli.Flag{
+					&cli.Float64Flag{
+						Name:     "cpu",
+						Aliases:  []string{"c"},
+						Usage:    "how many cpu to occupy",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "memory",
+						Aliases:  []string{"m", "mem"},
+						Usage:    "how much memory to occupy like 1M or 1G, support K, M, G, T",
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:     "storage",
+						Aliases:  []string{"s"},
+						Usage:    "how much storage to occupy like 1M or 1G, support K, M, G, T",
+						Required: true,
+					},
+					&cli.BoolFlag{
+						Name:  "cpu-bind",
+						Usage: "bind cpu or not",
+						Value: false,
+					},
+				},
+			},
+			{
 				Name:      "nodes",
 				Usage:     "list all nodes in one pod",
 				ArgsUsage: podArgsUsage,

--- a/describe/pod.go
+++ b/describe/pod.go
@@ -17,7 +17,7 @@ type capacityOfNode struct {
 
 type capacityOfPod struct {
 	Total int               `json:"total" yaml:"total"`
-	Nodes []*capacityOfNode `json:"nodes" yaml:"nodes`
+	Nodes []*capacityOfNode `json:"nodes" yaml:"nodes"`
 }
 
 // Pods describes a list of Pod

--- a/describe/pod.go
+++ b/describe/pod.go
@@ -1,11 +1,24 @@
 package describe
 
 import (
+	"fmt"
 	"os"
+	"sort"
+	"strconv"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	corepb "github.com/projecteru2/core/rpc/gen"
 )
+
+type capacityOfNode struct {
+	Name     string `json:"name" yaml:"name"`
+	Capacity int    `json:"capacity" yaml:"capacity"`
+}
+
+type capacityOfPod struct {
+	Total int               `json:"total" yaml:"total"`
+	Nodes []*capacityOfNode `json:"nodes" yaml:"nodes`
+}
 
 // Pods describes a list of Pod
 // output format can be json or yaml or table
@@ -18,6 +31,57 @@ func Pods(pods ...*corepb.Pod) {
 	default:
 		describePods(pods)
 	}
+}
+
+// PodCapacity describes the capacity remained based on a given specification.
+// output format can be json or yaml or table
+func PodCapacity(total int64, capacityMap map[string]int64) {
+	capPod := &capacityOfPod{
+		Total: int(total),
+	}
+
+	capPod.Nodes = make([]*capacityOfNode, 0, len(capacityMap))
+	for name, capacity := range capacityMap {
+		capPod.Nodes = append(capPod.Nodes, &capacityOfNode{
+			Name:     name,
+			Capacity: int(capacity),
+		})
+	}
+
+	// sort by remained capacity in descending order
+	sort.Slice(capPod.Nodes, func(i, j int) bool {
+		return capPod.Nodes[i].Capacity >= capPod.Nodes[j].Capacity
+	})
+
+	switch {
+	case isJSON():
+		describeAsJSON(capPod)
+	case isYAML():
+		describeAsYAML(capPod)
+	default:
+		describePodCapacities(capPod)
+	}
+}
+
+func describePodCapacities(capacity *capacityOfPod) {
+	fmt.Println("Total:", capacity.Total)
+
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.AppendHeader(table.Row{"Node", "Capacity"})
+
+	nameRow := []string{}
+	descRow := []string{}
+	for _, node := range capacity.Nodes {
+		nameRow = append(nameRow, node.Name)
+		descRow = append(descRow, strconv.FormatInt(int64(node.Capacity), 10))
+	}
+	rows := [][]string{nameRow, descRow}
+
+	t.AppendRows(toTableRows(rows))
+	t.AppendSeparator()
+	t.SetStyle(table.StyleLight)
+	t.Render()
 }
 
 func describePods(pods []*corepb.Pod) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/uuid v1.1.1
 	github.com/jedib0t/go-pretty/v6 v6.0.6
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/kless/term v0.0.0-20161130133337-e551c64f56c0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190908185732-236ed259b199/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=


### PR DESCRIPTION
# Why We Need It

For operators they may need a tool to do pre-calculation at the POD based on a given specification to figure out how many resources available for current/future operations.  

# How to Implement it

Although there are various parameters creating a workload there are only several necessary ones to do calculations. They are:

param | format
--- | ---
cpu | float
cpu-bind | bool, it may quite affect the amount of resources
memory | string, human readable format: 1M/1G/100G
storage | string, human readable format: 1M/1G/100G
podname | string

To get the capacity on every node for real the deploying strategy may not like what we would use in real creations. We use `DUMMY` here.

# What it Looks Like

Please check the screenshot below (cli: `./cli pod capacity --cpu 0.2 --mem 100M --s 1 dev1`):

```text
Total: 115
┌───────┬──────────┐
│ NODE  │ CAPACITY │
├───────┼──────────┤
│ dev04 │ 58       │
│ dev03 │ 57       │
└───────┴──────────┘
```
