### PR TITLE
accept []string as commands

### DIFF
--- a/cmd/lambda/run.go
+++ b/cmd/lambda/run.go
@@ -80,7 +80,6 @@ func generateLambdaOptions(c *cli.Context) (*corepb.RunAndWaitOptions, error) {
 		return nil, errors.New("[Lambda] no commands")
 	}
 
-	commands := c.Args().Slice()
 	network := c.String("network")
 
 	memRequest, err := utils.ParseRAMInHuman(c.String("memory-request"))
@@ -99,7 +98,7 @@ func generateLambdaOptions(c *cli.Context) (*corepb.RunAndWaitOptions, error) {
 			Name: "lambda",
 			Entrypoint: &corepb.EntrypointOptions{
 				Name:       c.String("name"),
-				Command:    strings.Join(commands, " && "),
+				Commands:   c.Args().Slice(),
 				Privileged: c.Bool("privileged"),
 				Dir:        c.String("working-dir"),
 			},

--- a/cmd/workload/deploy.go
+++ b/cmd/workload/deploy.go
@@ -203,7 +203,7 @@ func generateDeployOptions(c *cli.Context) (*corepb.DeployOptions, error) {
 		Name: specs.Appname,
 		Entrypoint: &corepb.EntrypointOptions{
 			Name:        entry,
-			Command:     entrypoint.Command,
+			Commands:    entrypoint.GetCommands(),
 			Privileged:  entrypoint.Privileged,
 			Dir:         entrypoint.Dir,
 			Log:         logConfig,

--- a/cmd/workload/replace.go
+++ b/cmd/workload/replace.go
@@ -175,7 +175,7 @@ func generateReplaceOptions(c *cli.Context) (*corepb.DeployOptions, error) {
 		Name: specs.Appname,
 		Entrypoint: &corepb.EntrypointOptions{
 			Name:        entry,
-			Command:     entrypoint.Command,
+			Commands:    entrypoint.GetCommands(),
 			Privileged:  entrypoint.Privileged,
 			Dir:         entrypoint.Dir,
 			Log:         logConfig,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/juju/testing v0.0.0-20201216035041-2be42bba85f3 // indirect
 	github.com/kless/term v0.0.0-20161130133337-e551c64f56c0 // indirect
 	github.com/pkg/term v1.1.0
-	github.com/projecteru2/core v0.0.0-20210415093154-1f9362198e8a
+	github.com/projecteru2/core v0.0.0-20210419020340-872926788608
 	github.com/sethgrid/curse v0.0.0-20181231162520-d4ee583ebf0f
 	github.com/sethvargo/go-signalcontext v0.1.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/projecteru2/core v0.0.0-20210412065234-d0cd929c9739 h1:1KX5LLjQO4iPCR
 github.com/projecteru2/core v0.0.0-20210412065234-d0cd929c9739/go.mod h1:K5MyiUV8JDMSTIFE7CHY6TISS+nVTHV71hHl9aMrBdU=
 github.com/projecteru2/core v0.0.0-20210412071726-d5e8a01c0b78 h1:4C/kJEGcq1s98ZHSlG39EFAAD3WymEyP7czIUUFw/d4=
 github.com/projecteru2/core v0.0.0-20210412071726-d5e8a01c0b78/go.mod h1:K5MyiUV8JDMSTIFE7CHY6TISS+nVTHV71hHl9aMrBdU=
-github.com/projecteru2/core v0.0.0-20210415093154-1f9362198e8a h1:JUSljwOZLDnV0B6PW19qc204QcOlNCtVU798flvmLxc=
-github.com/projecteru2/core v0.0.0-20210415093154-1f9362198e8a/go.mod h1:K5MyiUV8JDMSTIFE7CHY6TISS+nVTHV71hHl9aMrBdU=
+github.com/projecteru2/core v0.0.0-20210419020340-872926788608 h1:tVuf1DTpLiPMTa60CXLUy41xuJeTVV1lXy3rCsPEcw8=
+github.com/projecteru2/core v0.0.0-20210419020340-872926788608/go.mod h1:K5MyiUV8JDMSTIFE7CHY6TISS+nVTHV71hHl9aMrBdU=
 github.com/projecteru2/libyavirt v0.0.0-20201204100854-3646a3f5f5e5 h1:FxDFP3qtEi0RsnB6X2IpHTdklttamesggNCU7wb6rsY=
 github.com/projecteru2/libyavirt v0.0.0-20201204100854-3646a3f5f5e5/go.mod h1:9/SNmdphwl12ubwihkRa9YtOozM6liYLDxsricra1mY=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/specs.yaml.example
+++ b/specs.yaml.example
@@ -2,6 +2,12 @@ appname: "elb"
 entrypoints:
   release:
     cmd: "/usr/local/openresty/bin/openresty -p /elb/server -c /elb/conf/release.conf"
+    commands:
+      - /usr/local/openresty/bin/openresty
+      - -p
+      - /elb/server
+      - -c
+      - /elb/conf/release.conf
     restart: always
     dir: /elb
     publish:

--- a/types/specs.go
+++ b/types/specs.go
@@ -20,7 +20,7 @@ type Specs struct {
 // Entrypoint is a facade of old stype `cmd` and new stype `commands`
 type Entrypoint struct {
 	types.Entrypoint `yaml:",inline"`
-	Command          string `yaml:"cmd",omitempty"`
+	Command          string `yaml:"cmd,omitempty"`
 }
 
 // GetCommands .

--- a/types/specs.go
+++ b/types/specs.go
@@ -1,16 +1,32 @@
 package types
 
 import (
+	"strings"
+
 	"github.com/projecteru2/core/types"
 )
 
 // Specs correspond to app.yaml in repository
 type Specs struct {
-	Appname        string                      `yaml:"appname,omitempty"`
-	Entrypoints    map[string]types.Entrypoint `yaml:"entrypoints,omitempty,flow"`
-	Volumes        []string                    `yaml:"volumes,omitempty,flow"`
-	VolumesRequest []string                    `yaml:"volumes_request,omitempty,flow"`
-	Labels         map[string]string           `yaml:"labels,omitempty,flow"`
-	DNS            []string                    `yaml:"dns,omitempty,flow"`
-	ExtraHosts     []string                    `yaml:"extra_hosts,omitempty,flow"`
+	Appname        string                `yaml:"appname,omitempty"`
+	Entrypoints    map[string]Entrypoint `yaml:"entrypoints,omitempty,flow"`
+	Volumes        []string              `yaml:"volumes,omitempty,flow"`
+	VolumesRequest []string              `yaml:"volumes_request,omitempty,flow"`
+	Labels         map[string]string     `yaml:"labels,omitempty,flow"`
+	DNS            []string              `yaml:"dns,omitempty,flow"`
+	ExtraHosts     []string              `yaml:"extra_hosts,omitempty,flow"`
+}
+
+// Entrypoint is a facade of old stype `cmd` and new stype `commands`
+type Entrypoint struct {
+	types.Entrypoint `yaml:",inline"`
+	Command          string `yaml:"cmd",omitempty"`
+}
+
+// GetCommands .
+func (e Entrypoint) GetCommands() []string {
+	if len(e.Commands) > 0 {
+		return e.Commands
+	}
+	return strings.Split(e.Command, " ")
 }


### PR DESCRIPTION
1. spec 接受两种 cmd 方式: 

```
appname: "elb"
entrypoints:
  release:
    cmd: "/usr/local/openresty/bin/openresty -p /elb/server -c /elb/conf/release.conf"
    commands:
      - /usr/local/openresty/bin/openresty
      - -p
      - /elb/server
      - -c
      - /elb/conf/release.conf
```

如果同时出现 `cmd` 和 `commands` 以 `commands` 为准.

2. lambda 的 cmd

lambda 的 cmd 直接被读取为 `[]string`, 所以如果需求是运行多个命令, 比如 `true && echo a` 这种, 要注意 `&&` / `|` / `||` 都是 shell 指令, 必须手动指示使用 shell:

```
cli lambda --name zc --pod local --image bash bash -c 'echo 11 | tee /tmp/a'
```

总结: 本质上就是想象自己录入的参数直接变成 []string 扔给 execvp(3), 应该不难理解...
