### PR TITLE
feat: add node name specified feature into `pod capacity`

### DIFF
--- a/cmd/pod/cmd.go
+++ b/cmd/pod/cmd.go
@@ -82,6 +82,12 @@ func Command() *cli.Command {
 						Usage: "bind cpu or not",
 						Value: false,
 					},
+					&cli.StringSliceFlag{
+						Name:     "node",
+						Aliases:  []string{"nodename", "n"},
+						Usage:    "Specified the node(s) should join into the calculation. Could be specified multiple times with different names",
+						Required: false,
+					},
 				},
 			},
 			{


### PR DESCRIPTION
# Why we need this

Add the ability to calculate the capacity on specified nodes in a pod.  