### PR TITLE
Fix the mis-referenced args name in `pod capacity`

### DIFF
--- a/cmd/pod/capacity.go
+++ b/cmd/pod/capacity.go
@@ -82,7 +82,7 @@ func cmdPodCapacity(c *cli.Context) error {
 		podname:   name,
 		nodenames: c.StringSlice("nodename"),
 
-		cpu:     c.Float64("cpu-limit"),
+		cpu:     c.Float64("cpu"),
 		cpuBind: c.Bool("cpu-bind"),
 		memory:  mem,
 		storage: storage,


### PR DESCRIPTION
orz