### PR TITLE
skip setting "available: false" in "node down"

### DIFF
--- a/cmd/node/down.go
+++ b/cmd/node/down.go
@@ -37,7 +37,6 @@ func (o *setNodeDownOptions) run(ctx context.Context) error {
 	if do {
 		_, err := o.client.SetNode(ctx, &corepb.SetNodeOptions{
 			Nodename:  o.name,
-			StatusOpt: corepb.TriOpt_FALSE,
 			BypassOpt: corepb.TriOpt_TRUE,
 		})
 		if err != nil {


### PR DESCRIPTION
按照最新的会议精神，node down这个命令只应该设置bypass，而不应设置available的值。否则会产生比较恶心的后果：

1. cli设置了available: false，
2. core会删除node status，
3. selfmon会调用set node down，
4. node上所有的workload都会被设置为running: false。