### PR TITLE
Add send large file from cli

### DIFF
--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -217,6 +217,18 @@ func Command() *cli.Command {
 				},
 			},
 			{
+				Name:      "sendlarge",
+				Usage:     "send single large file to workload(s)",
+				ArgsUsage: sendArgsUsage,
+				Action:    utils.ExitCoder(cmdWorkloadSendLarge),
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "file",
+						Usage: "copy local files to workload, only can use single time. src_path:dst_path[:mode[:uid:gid]]",
+					},
+				},
+			},
+			{
 				Name:      "dissociate",
 				Usage:     "dissociate workload(s) from eru, return it resource but not remove it",
 				ArgsUsage: workloadArgsUsage,

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -224,7 +224,7 @@ func Command() *cli.Command {
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{
 						Name:  "file",
-						Usage: "copy local files to workload, only can use single time. src_path:dst_path[:mode[:uid:gid]]",
+						Usage: "copy local file to workload, only can use single time. src_path:dst_path[:mode[:uid:gid]]",
 					},
 				},
 			},

--- a/cmd/workload/sendlarge.go
+++ b/cmd/workload/sendlarge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projecteru2/cli/cmd/utils"
 	corepb "github.com/projecteru2/core/rpc/gen"
+	"github.com/projecteru2/core/types"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -59,7 +60,7 @@ func (o *sendLargeWorkloadsOptions) run(ctx context.Context) error {
 }
 
 func (o *sendLargeWorkloadsOptions) toSendLargeFileChunks() []*corepb.FileOptions {
-	const maxChunkSize = 2 << 10
+	maxChunkSize := types.SendLargeFileChunkSize
 	ret := make([]*corepb.FileOptions, 0)
 	for idx := 0; idx < len(o.content); idx += maxChunkSize {
 		fileOption := &corepb.FileOptions{

--- a/cmd/workload/sendlarge.go
+++ b/cmd/workload/sendlarge.go
@@ -1,0 +1,116 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/projecteru2/cli/cmd/utils"
+	corepb "github.com/projecteru2/core/rpc/gen"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+type sendLargeWorkloadsOptions struct {
+	client corepb.CoreRPCClient
+	// workload ids
+	ids     []string
+	dst     string
+	content []byte
+	modes   *corepb.FileMode
+	owners  *corepb.FileOwner
+}
+
+func (o *sendLargeWorkloadsOptions) run(ctx context.Context) error {
+	stream, err := o.client.SendLargeFile(ctx)
+	if err != nil {
+		logrus.Errorf("[SendLarge] Failed send %s", o.dst)
+		return err
+	}
+
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return
+			}
+
+			if msg.Error != "" {
+				logrus.Errorf("[SendLarge] Failed send %s to %s", msg.Path, msg.Id)
+			} else {
+				logrus.Infof("[SendLarge] Send %s to %s success", msg.Path, msg.Id)
+			}
+		}
+	}()
+
+	fileOptions := o.toSendLargeFileChunks()
+	for _, chunk := range fileOptions {
+		err := stream.Send(chunk)
+		if err != nil {
+			logrus.Errorf("[SendLarge] Failed send %s", chunk.Dst)
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *sendLargeWorkloadsOptions) toSendLargeFileChunks() []*corepb.FileOptions {
+	const maxChunkSize = 2 << 10
+	ret := make([]*corepb.FileOptions, 0)
+	for idx := 0; idx < len(o.content); idx += maxChunkSize {
+		fileOption := &corepb.FileOptions{
+			Ids:   o.ids,
+			Dst:   o.dst,
+			Size:  int64(len(o.content)),
+			Mode:  o.modes,
+			Owner: o.owners,
+		}
+		if idx+maxChunkSize > len(o.content) {
+			fileOption.Chunk = o.content[idx:]
+		} else {
+			fileOption.Chunk = o.content[idx : idx+maxChunkSize]
+		}
+		ret = append(ret, fileOption)
+	}
+	return ret
+}
+
+func cmdWorkloadSendLarge(c *cli.Context) error {
+	client, err := utils.NewCoreRPCClient(c)
+	if err != nil {
+		return err
+	}
+
+	content, modes, owners := utils.GenerateFileOptions(c)
+	if len(content) == 0 {
+		return fmt.Errorf("files should not be empty")
+	}
+	if len(content) >= 2 {
+		return fmt.Errorf("can not send multiple files at the same time")
+	}
+
+	ids := c.Args().Slice()
+	if len(ids) == 0 {
+		return fmt.Errorf("Workload ID(s) should not be empty")
+	}
+
+	targetFileName := func() string {
+		for key := range content {
+			return key
+		}
+		return ""
+	}()
+	o := &sendLargeWorkloadsOptions{
+		client:  client,
+		ids:     ids,
+		dst:     targetFileName,
+		content: content[targetFileName],
+		modes:   modes[targetFileName],
+		owners:  owners[targetFileName],
+	}
+	return o.run(c.Context)
+}

--- a/cmd/workload/sendlarge.go
+++ b/cmd/workload/sendlarge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/projecteru2/cli/cmd/utils"
 	corepb "github.com/projecteru2/core/rpc/gen"
@@ -30,7 +31,10 @@ func (o *sendLargeWorkloadsOptions) run(ctx context.Context) error {
 		return err
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			msg, err := stream.Recv()
 			if err == io.EOF {
@@ -56,6 +60,8 @@ func (o *sendLargeWorkloadsOptions) run(ctx context.Context) error {
 			return err
 		}
 	}
+	stream.CloseSend()
+	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
关于cli的send命令，之前的send是直接整个文件发到core里面，但是core的grpc配置为单条message最大只能为20M，所以有些文件是无法传输到core端的。

这是对于core的修改的客户端适配，保存了原有的send方法，并增加了新的sendlarge方法

